### PR TITLE
[I-9] Position Logos in Section Boxes Correctly

### DIFF
--- a/src/app/components/AboutMeSection.jsx
+++ b/src/app/components/AboutMeSection.jsx
@@ -21,7 +21,7 @@ const AboutMeSection = () => {
             Education
           </h2>
           <div className='section-box grid grid-cols-2'>
-            <div>
+            <div className='flex flex-col justify-between'>
               <h3 className='title box-heading'>
                 {EDUCATION.university}
               </h3>
@@ -37,9 +37,9 @@ const AboutMeSection = () => {
               <Image
                 src={ChapmanLogo}
                 alt='Chapman Logo'
-                className='text-sm font-semibold'
-                width={200}
-                height={200}
+                className='text-sm font-semibold self-start mt-auto'
+                width={250}
+                height={250}
               />
             </div>
             <div>

--- a/src/app/components/AboutMeSection.jsx
+++ b/src/app/components/AboutMeSection.jsx
@@ -21,7 +21,7 @@ const AboutMeSection = () => {
             Education
           </h2>
           <div className='section-box grid grid-cols-2'>
-            <div className='flex flex-col justify-between'>
+            <div className='flex flex-col justify-between mr-6'>
               <h3 className='title box-heading'>
                 {EDUCATION.university}
               </h3>

--- a/src/app/components/ExperienceItem.jsx
+++ b/src/app/components/ExperienceItem.jsx
@@ -8,10 +8,10 @@ const ExperienceItem = ({
 
   return (
     <div className='section-box grid grid-cols-2 mb-20'>
+      <div className='flex flex-col justify-between'>
         <h3 className='title box-heading col-span-2'>
           {company}
         </h3>
-      <div>
         <p className='title'>
           {position}
         </p>
@@ -24,7 +24,7 @@ const ExperienceItem = ({
         <Image
           src={logo}
           alt={`${company} Logo`}
-          className='text-sm font-light'
+          className='text-sm font-light self-start mt-auto pt-2'
           width={100}
           height={100}
         />

--- a/src/app/components/ExperienceItem.jsx
+++ b/src/app/components/ExperienceItem.jsx
@@ -8,7 +8,7 @@ const ExperienceItem = ({
 
   return (
     <div className='section-box grid grid-cols-2 mb-20'>
-      <div className='flex flex-col justify-between'>
+      <div className='flex flex-col justify-between mr-6'>
         <h3 className='title box-heading col-span-2'>
           {company}
         </h3>


### PR DESCRIPTION
## Summary
[[Issue-9]](https://github.com/michelleezhangg/Personal-Website-Portfolio/issues/9#issue-2587682109): Positioned the logos in section boxes of the Education and Professional Experience sections to be in the lower left corner.

## Implementation Details
- Surrounded the contents with a `div` and made it a column flex-box to move the logo to the correct position.
- Performed the same operation for the Education box and Professional Experience boxes.
- Adding extra padding to ensure the logo has some distance to the date.

## Testing Instructions
1. Run the project locally.
2. Be able to view the changes in both sections.
3. Test in different browsers (Chrome, Firefox, and Safari).
4. Test with all different desktop window sizes.