### PR TITLE
[I-12] Change Message to a Text Area

### DIFF
--- a/src/app/components/ContactMeSection.jsx
+++ b/src/app/components/ContactMeSection.jsx
@@ -129,7 +129,7 @@ const ContactMeSection = () => {
                   type='message'
                   id='message'
                   required
-                  className='bg-white border border-black text-sm rounded-lg block w-full p-2.5 resize-vertical min-h-[42px]'
+                  className='bg-white border border-black text-sm rounded-lg block w-full p-2.5 resize-vertical min-h-[42px] max-h-[400px]'
                   placeholder={MESSAGE_PLACEHOLDER}
                 ></textarea>
               </div>

--- a/src/app/components/ContactMeSection.jsx
+++ b/src/app/components/ContactMeSection.jsx
@@ -124,14 +124,14 @@ const ContactMeSection = () => {
                 >
                   Message
                 </label>
-                <input
+                <textarea
                   name='message'
                   type='message'
                   id='message'
                   required
-                  className='bg-white border border-black text-sm rounded-lg block w-full p-2.5'
+                  className='bg-white border border-black text-sm rounded-lg block w-full p-2.5 resize-vertical min-h-[42px]'
                   placeholder={MESSAGE_PLACEHOLDER}
-                />
+                ></textarea>
               </div>
               <button
                 type='submit'

--- a/src/app/components/ContactMeSection.jsx
+++ b/src/app/components/ContactMeSection.jsx
@@ -129,7 +129,7 @@ const ContactMeSection = () => {
                   type='message'
                   id='message'
                   required
-                  className='bg-white border border-black text-sm rounded-lg block w-full p-2.5 resize-vertical min-h-[42px] max-h-[400px]'
+                  className='bg-white border border-black text-sm rounded-lg block w-full p-2.5 resize-vertical min-h-[42px] max-h-[300px]'
                   placeholder={MESSAGE_PLACEHOLDER}
                 ></textarea>
               </div>


### PR DESCRIPTION
## Summary
[[Issue-12]](https://github.com/michelleezhangg/Personal-Website-Portfolio/issues/12#issue-2587686211): Change the `Message` box in the Contact Me section into a `<textarea>`.

## Implementation Details
- Change the `input` for the `Message` input into `<textarea>`.
- Adjust the minimum resizable height to match the `Email` and `Subject` inputs.

## Testing Instructions
1. Run the project locally.
2. Adjust the size of the text area to the minimum and see if the height matches the other inputs' heights.
3. Adjust the size of the text area to the maximum and test to see if the maximum size affects anything else.

## Screenshot
<img width="1512" alt="Screenshot of the resting Message box" src="https://github.com/user-attachments/assets/53a03a9d-49c7-4954-9daf-613d8711d4f2">
<img width="1512" alt="Screenshot of the minimized Message box" src="https://github.com/user-attachments/assets/0e68eb76-5101-43e2-939d-3257d74d99a0">
<img width="1512" alt="Screenshot of the maximized Message box" src="https://github.com/user-attachments/assets/bbd4ec8f-270f-46c7-8f38-05a4bdbc882e">