### PR TITLE
[I-47] Add First Name and Last Name Fields to Contact Form

### DIFF
--- a/src/app/api/send/route.js
+++ b/src/app/api/send/route.js
@@ -13,8 +13,8 @@ export async function POST(req) {
   try {
     console.log('Received request:', req);
     // Parse the request body
-    const { email, subject, message } = await req.json();
-    console.log('Parsed request body:', { email, subject, message });
+    const { firstName, lastName, email, subject, message } = await req.json();
+    console.log('Parsed request body:', { firstName, lastName, email, subject, message });
 
     // Validate email format
     if (!emailRegex.test(email)) {
@@ -25,7 +25,8 @@ export async function POST(req) {
     }
 
     // Validate other required fields
-    if (!subject || !message) {
+    if (!firstName || !lastName || !subject || !message) {
+      console.log('Fields:', { firstName, lastName, email, subject, message });
       return NextResponse.json({
         error: 'Missing required fields',
         status: 400,
@@ -39,7 +40,7 @@ export async function POST(req) {
       subject: CONTACT.user_confirmation_email.subject,
       react: (
         <div>
-          <p>Hello {email},</p>
+          <p>Hello {firstName} {lastName},</p>
           <p>{CONTACT.user_confirmation_email.body}</p>
           <p><strong>Subject</strong>: {subject}</p>
           <p><strong>Message</strong>: {message}</p>

--- a/src/app/components/ContactMeSection.jsx
+++ b/src/app/components/ContactMeSection.jsx
@@ -95,7 +95,43 @@ const ContactMeSection = () => {
         {/* Right Side: Submission Form */}
         <div>
             <form className='flex flex-col gap-2' onSubmit={handleSubmit}>
-              <div className='mb-6'>
+              <div className='flex gap-2 mb-4'> {/* First and Last Name Inputs */}
+                <div className='flex-1 mr-2'>
+                  <label
+                    htmlFor='first-name'
+                    type='text'
+                    className='title block text-sm mb-2'
+                  >
+                    First Name
+                  </label>
+                  <input
+                    name='first-name'
+                    type='text'
+                    id='first-name'
+                    required
+                    className='bg-white border border-black text-sm rounded-lg block w-full p-2.5'
+                    placeholder={CONTACT.placeholders.first_name}
+                  />
+                </div>
+                <div className='flex-1'>
+                  <label
+                    htmlFor='last-name'
+                    type='text'
+                    className='title block text-sm mb-2'
+                  >
+                    Last Name
+                  </label>
+                  <input
+                    name='first-name'
+                    type='text'
+                    id='first-name'
+                    required
+                    className='bg-white border border-black text-sm rounded-lg block w-full p-2.5'
+                    placeholder={CONTACT.placeholders.last_name}
+                  />
+                </div>
+              </div>
+              <div className='mb-4'>
                 <label
                   htmlFor='email'
                   type='email'
@@ -112,7 +148,7 @@ const ContactMeSection = () => {
                   placeholder={CONTACT.placeholders.email}
                 />
               </div>
-              <div className='mb-6'>
+              <div className='mb-4'>
                 <label
                   htmlFor='subject'
                   className='title block text-sm mb-2'
@@ -128,7 +164,7 @@ const ContactMeSection = () => {
                   placeholder={CONTACT.placeholders.subject}
                 />
               </div>
-              <div className='mb-6'>
+              <div className='mb-4'>
                 <label
                   htmlFor='message'
                   className='title block text-sm mb-2'

--- a/src/app/components/ContactMeSection.jsx
+++ b/src/app/components/ContactMeSection.jsx
@@ -16,6 +16,8 @@ const ContactMeSection = () => {
     setError('');
 
     const data = {
+      firstName: e.target.firstName.value,
+      lastName: e.target.lastName.value,
       email: e.target.email.value,
       subject: e.target.subject.value,
       message: e.target.message.value,
@@ -98,16 +100,16 @@ const ContactMeSection = () => {
               <div className='flex gap-2 mb-4'> {/* First and Last Name Inputs */}
                 <div className='flex-1 mr-2'>
                   <label
-                    htmlFor='first-name'
+                    htmlFor='firstName'
                     type='text'
                     className='title block text-sm mb-2'
                   >
                     First Name
                   </label>
                   <input
-                    name='first-name'
+                    name='firstName'
                     type='text'
-                    id='first-name'
+                    id='firstName'
                     required
                     className='bg-white border border-black text-sm rounded-lg block w-full p-2.5'
                     placeholder={CONTACT.placeholders.first_name}
@@ -115,16 +117,16 @@ const ContactMeSection = () => {
                 </div>
                 <div className='flex-1'>
                   <label
-                    htmlFor='last-name'
+                    htmlFor='lastName'
                     type='text'
                     className='title block text-sm mb-2'
                   >
                     Last Name
                   </label>
                   <input
-                    name='first-name'
+                    name='lastName'
                     type='text'
-                    id='first-name'
+                    id='lastName'
                     required
                     className='bg-white border border-black text-sm rounded-lg block w-full p-2.5'
                     placeholder={CONTACT.placeholders.last_name}

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -395,8 +395,10 @@ export const PROJECTS = [
 export const CONTACT = {
   bio: 'Feel free to reach out to me through my socials or this contact form!',
   placeholders: {
+    first_name: 'First Name',
+    last_name: 'Last Name',
     email: 'name@gmail.com',
-    subject: 'Just saying hi',
+    subject: 'Just saying hi...',
     message: "Let's talk about...",
   },
   user_confirmation_email: {


### PR DESCRIPTION
## Summary
[[Issue-47]](https://github.com/michelleezhangg/Personal-Website-Portfolio/issues/47#issue-2605815670): Add `First Name` and `Last Name` to the email Contact Form for the user confirmation email to address the user directly with first and last name in the form of: Hi `First Name` `Last Name`, ...

## Implementation Details
- Frontend: Add empty fields titled `First Name` and `Last Name` in a row configuration in the contact form.
- Backend: Add `First Name` and `Last Name` to the submission data and alter the user confirmation email to address the user with their first and last name.
- Update `constants.js` with the placeholders for the new fields.

## Testing Details
- Submit forms with First and Last Name and confirm a 200 status.
- Try submitting forms without filling in the name fields, but should not be able to because those fields are `required`.
- Confirm the correct formatting in the user confirmation email with the first and last name present.